### PR TITLE
Add matter-netman and gn packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-# matter-openwrt
+# Matter OpenWRT Feed
+
+This repository is an [OpenWRT](https://openwrt.org) feed that packages [Matter](https://github.com/project-chip/connectedhomeip) software components for the OpenWRT operating system. It forms part of a reference implementation for Matter device types in the Routers & Access Points category.
+
+Matter is a unified, open-source application-layer connectivity standard built to enable developers and device manufacturers to connect and build reliable, and secure ecosystems and increase compatibility among connected home devices. Visit [buildwithmatter.com](http://buildwithmatter.com) to learn more.
+
+## Usage
+
+This repository is intended to be included as a package feed in an OpenWRT buildroot, and familiarity with the configuration and use of the OpenWRT build system is assumed in the following instructions. Please refer to the [OpenWRT Developer Guide](https://openwrt.org/docs/guide-developer/start) for general guidance on building an OpenWRT system.
+
+Note that this repository is aimed primarily at Matter implementers and OpenWRT integrators, and provides source packages only.
+
+### Adding the feed
+
+Add the following line to `feeds.conf` (ensure the OpenWRT `packages` feed is also present; it's definition can be copied from `feeds.conf.default` if necessary):
+
+```
+src-git matter https://github.com/project-chip/matter-openwrt.git
+```
+
+Run the following commands to fetch the feed and install the `matter-netman` package into the build:
+
+```
+$ ./scripts/feeds update packages matter
+$ ./scripts/feeds install matter-netman
+```
+
+### Build configuration
+
+For a minimal configuration, overwrite the `.config` file with the following lines and then run `make defconfig`:
+
+```
+CONFIG_PACKAGE_wpad-basic-wolfssl=n
+CONFIG_PACKAGE_wpad-openssl=y
+CONFIG_PACKAGE_matter-netman=y
+```
+
+Note that since the Matter SDK is configured to build using OpenSSL, it is recommended to also use OpenSSL as the TLS backend for hostapd / wpad.
+
+## License
+
+Matter-OpenWRT is released under the [Apache 2.0 license](./LICENSE).

--- a/devel/gn/Makefile
+++ b/devel/gn/Makefile
@@ -1,0 +1,79 @@
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gn
+PKG_SOURCE_URL:=https://gn.googlesource.com/gn
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_MIRROR:=0 # don't try OpenWRT mirror
+
+# GN versioning is based on the number of commits since the tag `initial-commit`,
+# and is exposed to build scripts via the `gn_version` variable. When updating
+# PKG_SOURCE_VERSION to a new commit hash, GN_VERSION needs to be obtained via
+#   git describe HEAD --match initial-commit | cut -f 3 -d -
+# and updated below.
+PKG_SOURCE_DATE:=2023-07-24
+PKG_SOURCE_VERSION:=62ac86a938c365ccdbbbd9a9b49fb72fa3d6eb81
+PKG_MIRROR_HASH:=231e7e663ec3a374bb86a50904b2af6562c29aad03de43f6b4a03d1be1f083c5
+GN_VERSION:=2116
+
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_HOST_ONLY:=1
+HOST_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+
+define Package/gn
+  SECTION:=devel
+  CATEGORY:=Development
+  TITLE:=gn
+  URL:=https://gn.googlesource.com/gn
+endef
+
+define Package/gn/description
+  GN is a meta-build system that generates build files for Ninja.
+endef
+
+define Host/Configure
+	cd $(HOST_BUILD_DIR) && $(HOST_CONFIGURE_VARS) \
+		$(STAGING_DIR_HOST)/bin/python build/gen.py --no-last-commit-position
+	echo "$$$$GN_LAST_COMMIT_HEADER" | \
+		VER_NUM=$(GN_VERSION) VER_STR="$(GN_VERSION) (`echo "$(PKG_SOURCE_VERSION)" | cut -c 1-12`)" \
+		perl -lpe 's/\$$$$(\w+)/$$$$ENV{$$$$1}/ge' >$(HOST_BUILD_DIR)/out/last_commit_position.h
+endef
+
+define Host/Compile
+	$(NINJA) -C $(HOST_BUILD_DIR)/out
+endef
+
+define Host/Install
+	$(INSTALL_DIR) $(1)/bin
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/out/gn $(1)/bin
+endef
+
+define GN_LAST_COMMIT_HEADER
+#ifndef OUT_LAST_COMMIT_POSITION_H_
+#define OUT_LAST_COMMIT_POSITION_H_
+#define LAST_COMMIT_POSITION_NUM $$VER_NUM
+#define LAST_COMMIT_POSITION "$$VER_STR"
+#endif // OUT_LAST_COMMIT_POSITION_H_
+endef
+export GN_LAST_COMMIT_HEADER
+
+$(eval $(call BuildPackage,gn))
+$(eval $(call HostBuild))

--- a/service/matter-netman/Makefile
+++ b/service/matter-netman/Makefile
@@ -1,0 +1,81 @@
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=matter-netman
+PKG_RELEASE:=1
+PKG_SOURCE_URL:=https://github.com/project-chip/connectedhomeip.git
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_MIRROR:=0 # don't try OpenWRT mirror
+PKG_SOURCE_SUBMODULES:=\
+  third_party/pigweed/repo \
+  third_party/jsoncpp/repo \
+  third_party/nlassert/repo \
+  third_party/nlio/repo
+
+# Hash can be regenerated with make package/matter-netman/check FIXUP=1
+PKG_SOURCE_DATE:=2023-06-21
+PKG_SOURCE_VERSION:=a816538e932cfa1d13891d7f103b6c2dd23a28ff
+PKG_MIRROR_HASH:=66b3da3e80b6aa8f9a5349ccb165c5ac48f707f22e0360d40c9f08a71619e9d3
+
+# Use local source dir for development
+# USE_SOURCE_DIR:=$(HOME)/workspace/connectedhomeip
+
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_DEPENDS:=gn/host
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/matter-netman
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Matter Network Manager Daemon
+  URL:=https://github.com/project-chip/connectedhomeip
+  DEPENDS:=+libstdcpp +libopenssl +glib2
+endef
+
+define Package/matter-netman/description
+  Matter Network Manager Daemon
+  Integrates a router / access point with the Matter IoT ecosystem.
+endef
+
+# The build environment contains host tools that can be shared between targets
+CHIP_BUILD_ENV_DIR:=$(STAGING_DIR_HOST)/share/chip-build-env
+OUT_DIR:=$(PKG_BUILD_DIR)/out/openwrt
+
+TARGET_CXXFLAGS += -Wno-format-nonliteral # https://github.com/openwrt/openwrt/issues/13016
+
+# lighting-app is a placeholder for now: https://github.com/project-chip/connectedhomeip/issues/28312
+define Build/Configure
+	mkdir -p $(OUT_DIR) && cd $(OUT_DIR) && \
+		$(CONFIGURE_VARS) $(PKG_BUILD_DIR)/scripts/configure \
+			--build-env-dir="$(CHIP_BUILD_ENV_DIR)" \
+			--project=examples/lighting-app/linux \
+			--target=$(GNU_TARGET_NAME)
+endef
+
+define Build/Compile
+	$(NINJA) -C $(OUT_DIR) chip-lighting-app
+endef
+
+define Package/matter-netman/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(OUT_DIR)/chip-lighting-app $(1)/usr/sbin
+endef
+
+$(eval $(call BuildPackage,matter-netman))


### PR DESCRIPTION
At this point matter-netman is something of a placeholder because there is no network manager example app yet; currently it just builds the lighting-app.

The host-only gn package is required to build matter-netman (ninja is already provided as part of the core OpenWRT tools).