### PR TITLE
Add workflow that builds our packages

### DIFF
--- a/.containers/matter-openwrt-build/Dockerfile
+++ b/.containers/matter-openwrt-build/Dockerfile
@@ -6,7 +6,8 @@ LABEL org.opencontainers.image.description="Pre-warmed OpenWrt SDK"
 ARG SRC_PACKAGES="openssl glib2"
 ARG CFG_PACKAGES="libopenssl glib2"
 
-ENV PATH="staging_dir/host/bin:$PATH"
+# Add host tools from WORKDIR (/builder) to PATH
+ENV PATH="/builder/staging_dir/host/bin:$PATH"
 RUN set -x && \
     grep -w 'base\|packages' feeds.conf.default > feeds.conf && \
     ./scripts/feeds update -a && \

--- a/.github/workflows/build-packages.yaml
+++ b/.github/workflows/build-packages.yaml
@@ -1,0 +1,30 @@
+name: build matter packages
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Run only the build step in the container rather than the whole job, because the UID of the
+      # buildbot user (1000) that owns the OpenWrt SDK files in /builder doesn't match the UID of
+      # the GitHub runner user (1001), causing file system permission issues.
+      - name: Build
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ghcr.io/project-chip/matter-openwrt-build:latest
+          options: --volume ${{ github.workspace }}:/workspace
+          run: |
+            set -x
+            wget -qO - https://github.com/openwrt/openwrt/pull/13000.patch | patch -p1
+            echo "src-link matter /workspace" >>feeds.conf
+            ./scripts/feeds update matter
+            ./scripts/feeds install -a -p matter -f
+            echo "CONFIG_PACKAGE_matter-netman=y" >.config
+            make defconfig
+            make -j package/matter-netman/compile V=s

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Matter OpenWrt Feed
 
+[![build matter packages](https://github.com/project-chip/matter-openwrt/actions/workflows/build-packages.yaml/badge.svg)](https://github.com/project-chip/matter-openwrt/actions/workflows/build-packages.yaml)
+
 This repository is an [OpenWrt](https://openwrt.org) feed that packages [Matter](https://github.com/project-chip/connectedhomeip) software components for the OpenWrt operating system. It forms part of a reference implementation for Matter device types in the Routers & Access Points category.
 
 Matter is a unified, open-source application-layer connectivity standard built to enable developers and device manufacturers to connect and build reliable, and secure ecosystems and increase compatibility among connected home devices. Visit [buildwithmatter.com](http://buildwithmatter.com) to learn more.

--- a/devel/gn/Makefile
+++ b/devel/gn/Makefile
@@ -58,7 +58,7 @@ define Host/Configure
 endef
 
 define Host/Compile
-	$(NINJA) -C $(HOST_BUILD_DIR)/out
+	$(NINJA) -C $(HOST_BUILD_DIR)/out gn
 endef
 
 define Host/Install

--- a/service/matter-netman/Makefile
+++ b/service/matter-netman/Makefile
@@ -26,9 +26,9 @@ PKG_SOURCE_SUBMODULES:=\
   third_party/nlio/repo
 
 # Hash can be regenerated with make package/matter-netman/check FIXUP=1
-PKG_SOURCE_DATE:=2023-06-21
-PKG_SOURCE_VERSION:=a816538e932cfa1d13891d7f103b6c2dd23a28ff
-PKG_MIRROR_HASH:=f5738a724b26bfc471f98007a05098d50f76ef7391ef9127a974ea7a283a9db8
+PKG_SOURCE_DATE:=2023-08-08
+PKG_SOURCE_VERSION:=367a0c672c18e0137e0162c15b78adbcb039a33a
+PKG_MIRROR_HASH:=5be101a07ffefe7e5bc25f2b3b497d2639e6b8bffb8ec41e173e0904ea814fa8
 
 # Use local source dir for development
 # USE_SOURCE_DIR:=$(HOME)/workspace/connectedhomeip
@@ -72,7 +72,11 @@ define Build/Configure
 		$(CONFIGURE_VARS) $(PKG_BUILD_DIR)/scripts/configure \
 			--build-env-dir="$(CHIP_BUILD_ENV_DIR)" \
 			--project=examples/lighting-app/linux \
-			--target=$(GNU_TARGET_NAME)
+			--target=$(GNU_TARGET_NAME) \
+			--enable-wifi=no \
+			--enable-openthread=no \
+			--enable-network-layer-ble=no \
+			--enable-tracing-support=no
 endef
 
 define Build/Compile


### PR DESCRIPTION
Also update Matter SDK to 367a0c67 to pick up configure script fixes and fix PATH in build docker image.