### PR TITLE
Add overlay mechanism and hostapd overlay package

### DIFF
--- a/.config.ci
+++ b/.config.ci
@@ -1,0 +1,4 @@
+CONFIG_ALL=n
+CONFIG_PACKAGE_wpad-basic-wolfssl=n
+CONFIG_PACKAGE_wpad-openssl=y
+CONFIG_PACKAGE_matter-netman=y

--- a/.containers/matter-openwrt-build/Dockerfile
+++ b/.containers/matter-openwrt-build/Dockerfile
@@ -3,8 +3,8 @@ FROM ghcr.io/openwrt/sdk:x86-generic-${OPENWRT_VERSION}
 LABEL org.opencontainers.image.description="Pre-warmed OpenWrt SDK"
 
 # Core packages to pre-build to speed up CI builds
-ARG SRC_PACKAGES="openssl glib2"
-ARG CFG_PACKAGES="libopenssl glib2"
+ARG SRC_PACKAGES="glib2 openssl ubus"
+ARG CFG_PACKAGES="glib2 libopenssl libubus"
 
 # Add host tools from WORKDIR (/builder) to PATH
 ENV PATH="/builder/staging_dir/host/bin:$PATH"
@@ -12,6 +12,8 @@ RUN set -x && \
     grep -w 'base\|packages' feeds.conf.default > feeds.conf && \
     ./scripts/feeds update -a && \
     ./scripts/feeds install ${SRC_PACKAGES} && \
-    for pkg in ${CFG_PACKAGES}; do echo "CONFIG_PACKAGE_${pkg}=y"; done >.config && \
+    echo "CONFIG_ALL=n" >.config && \
+    echo "CONFIG_AUTOREMOVE=n" >.config && \
+    for pkg in ${CFG_PACKAGES}; do echo "CONFIG_PACKAGE_${pkg}=y"; done >>.config && \
     make defconfig && \
-    make -j $(for pkg in ${SRC_PACKAGES}; do echo "package/${pkg}/compile"; done)
+    for pkg in ${SRC_PACKAGES}; do make -j "$(nproc)" "package/${pkg}/compile"; done

--- a/.github/workflows/build-packages.yaml
+++ b/.github/workflows/build-packages.yaml
@@ -19,12 +19,25 @@ jobs:
         with:
           image: ghcr.io/project-chip/matter-openwrt-build:latest
           options: --volume ${{ github.workspace }}:/workspace
+          shell: bash
           run: |
             set -x
             wget -qO - https://github.com/openwrt/openwrt/pull/13000.patch | patch -p1
-            echo "src-link matter /workspace" >>feeds.conf
+            echo "src-link --force matter /workspace" >>feeds.conf
             ./scripts/feeds update matter
-            ./scripts/feeds install -a -p matter -f
-            echo "CONFIG_PACKAGE_matter-netman=y" >.config
+            ./scripts/feeds install -a -p matter
+            cat feeds/matter/.config.ci >.config
             make defconfig
-            make -j package/matter-netman/compile V=s
+            failed=()
+            for pkg in $(awk -F '[[:space:]]|/' '/^Source-Makefile:/{print$(NF-1)}' feeds/matter.index); do
+              echo "::group::Building $pkg"
+              if ! make -j "$(nproc)" "package/$pkg/compile"; then
+                failed+=("$pkg")
+                make "package/$pkg/compile" V=s || true # re-run with verbose output
+              fi
+              echo "::endgroup::"
+            done
+            if [[ "${#failed[@]}" -gt 0 ]]; then
+              echo "ERROR: Some packages failed to build: ${failed[*]}"
+              exit 2
+            fi

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ Note that this repository is aimed primarily at Matter implementers and OpenWrt 
 Add the following line to `feeds.conf` (ensure the OpenWrt `packages` feed is also present; it's definition can be copied from `feeds.conf.default` if necessary):
 
 ```
-src-git matter https://github.com/project-chip/matter-openwrt.git
+src-git --force matter https://github.com/project-chip/matter-openwrt.git
 ```
 
-Run the following commands to fetch the feed and install the `matter-netman` package into the build:
+Run the following commands to fetch the feed and installs it into the build:
 
 ```
 $ ./scripts/feeds update packages matter
-$ ./scripts/feeds install matter-netman
+$ ./scripts/feeds install -a -p matter
 ```
 
 ### Build configuration
@@ -37,7 +37,7 @@ CONFIG_PACKAGE_wpad-openssl=y
 CONFIG_PACKAGE_matter-netman=y
 ```
 
-Note that since the Matter SDK is configured to build using OpenSSL, it is recommended to also use OpenSSL as the TLS backend for hostapd / wpad.
+Note that since the Matter SDK is currently configured to build using OpenSSL, it is recommended to also use OpenSSL as the TLS backend for hostapd / wpad.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add the following line to `feeds.conf` (ensure the OpenWrt `packages` feed is al
 src-git --force matter https://github.com/project-chip/matter-openwrt.git
 ```
 
-Run the following commands to fetch the feed and installs it into the build:
+Run the following commands to fetch the feed and install it into the build:
 
 ```
 $ ./scripts/feeds update packages matter

--- a/overlay/hostapd/Makefile
+++ b/overlay/hostapd/Makefile
@@ -1,0 +1,16 @@
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include ../overlay.mk
+$(eval $(call BuildPackageOverlay,network/services/hostapd))

--- a/overlay/overlay.mk
+++ b/overlay/overlay.mk
@@ -1,0 +1,54 @@
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+OVERLAY_MK:=$(abspath $(lastword $(MAKEFILE_LIST)))
+OVERLAY_SH:=$(dir $(OVERLAY_MK))overlay.sh
+
+define BuildPackageOverlay
+  $(call BuildPackageOverlay/$(if $(DUMP),Dump,Build),$(notdir $(1)),$(call overlay_base,$(1)))
+endef
+
+define BuildPackageOverlay/Dump
+  CURDIR:=$$(TOPDIR)/$(2)
+  include $$(CURDIR)/Makefile
+endef
+
+define BuildPackageOverlay/Build
+  include $$(TOPDIR)/rules.mk
+
+  OVERLAY_DIR:=$$(BUILD_DIR_BASE)/overlaypkg/$(1)
+  OVERLAY_BASE_DIR:=$$(TOPDIR)/$(2)
+  OVERLAY_STAMP:=$$(OVERLAY_DIR)/.stamp.$$(call overlay_hash,$$(CURDIR) $$(OVERLAY_BASE_DIR))
+  OVERLAY_TARGETS:=$$(filter-out check clean,$$(DEFAULT_SUBDIR_TARGETS))
+
+  default: $$(if $$(CHECK),check,compile)
+
+  $$(OVERLAY_STAMP):
+	rm -rf $$(OVERLAY_DIR)
+	$$(OVERLAY_SH) $$(OVERLAY_BASE_DIR) $$(CURDIR) $$(OVERLAY_DIR)
+	touch $$@
+
+  .PHONY: $$(OVERLAY_TARGETS)
+  $$(OVERLAY_TARGETS): $$(OVERLAY_STAMP)
+	$$(MAKE) -C $$(OVERLAY_DIR) $$@
+
+  .PHONY: clean
+  clean:
+	$$(MAKE) -C $$(OVERLAY_BASE_DIR) $$@
+	rm -rf $$(OVERLAY_DIR)
+endef
+
+overlay_base=$(or $(call overlay_find_core,$(1)),$(error Unable to locate core package '$(1)' (missing base feed?)))
+overlay_find_core=$(firstword $(foreach p,package/$(1) feeds/base/package/$(1),$(if $(wildcard $(TOPDIR)/$(p)/Makefile),$(p))))
+overlay_hash=$(shell find $(1) -type f -not -name '.*' | sort | mkhash md5)

--- a/overlay/overlay.sh
+++ b/overlay/overlay.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -e
+
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [[ "$#" -ne 3 ]]; then
+    echo "Usage: $0 BASE SRC DST" >&2
+    exit 1
+fi
+if [[ "${1#/}" == "$1" || "${2#/}" == "$2" ]]; then
+    echo "BASE and SRC paths must be absolute" >&2
+    exit 2
+fi
+if [[ -d "$3" ]]; then
+    echo "DST directory already exists" >&2
+    exit 2
+fi
+
+mkdir -p "$3/patches"
+ln -s "$1" "$3/.base"
+ln -s "$2" "$3/.overlay"
+
+cd "$3"
+shopt -s nullglob
+for p in .base/patches/* .overlay/patches/*; do
+    ln -s "../$p" patches/
+done
+for f in .base/*; do
+    [[ "$f" == .base/patches ]] && continue
+    ln -s "$f" .
+done


### PR DESCRIPTION
The overlay mechanism provides the ability to augment a core OpenWrt package with additional patches, without having to copy or fork the package definition.
    
Add .config.ci for use in the build workflow and build all packages.