### PR TITLE
Disable AUTOREMOVE and AUTOREBUILD in CI

### DIFF
--- a/.config.ci
+++ b/.config.ci
@@ -1,4 +1,6 @@
 CONFIG_ALL=n
+CONFIG_AUTOREMOVE=n
+CONFIG_AUTOREBUILD=n
 CONFIG_PACKAGE_wpad-basic-mbedtls=n
 CONFIG_PACKAGE_wpad-basic-openssl=n
 CONFIG_PACKAGE_wpad-basic-wolfssl=n

--- a/.containers/matter-openwrt-build/Dockerfile
+++ b/.containers/matter-openwrt-build/Dockerfile
@@ -11,6 +11,8 @@ RUN set -x && \
     ./scripts/feeds update -a && \
     ./scripts/feeds install ${SRC_PACKAGES} && \
     echo "CONFIG_ALL=n" >.config && \
+    echo "CONFIG_AUTOREMOVE=n" >>.config && \
+    echo "CONFIG_AUTOREBUILD=n" >>.config && \
     for pkg in ${CFG_PACKAGES}; do echo "CONFIG_PACKAGE_${pkg}=y"; done >>.config && \
     make defconfig && \
     for pkg in ${SRC_PACKAGES}; do make -j "$(nproc)" "package/${pkg}/compile"; done


### PR DESCRIPTION
This is so the build-packages workflow doesn't rebuild the depdendencies that have already been built in the matter-openwrt-build container.