### PR TITLE
Fix file mtimes in the docker container

### DIFF
--- a/.containers/matter-openwrt-build/Dockerfile
+++ b/.containers/matter-openwrt-build/Dockerfile
@@ -9,10 +9,13 @@ ARG CFG_PACKAGES="glib2 libopenssl libubus libavahi-client"
 RUN set -x && \
     grep -w 'base\|packages' feeds.conf.default | sed -e 's|git.openwrt.org/[^/]*|github.com/openwrt|' >feeds.conf && \
     ./scripts/feeds update -a && \
-    ./scripts/feeds install ./scripts/feeds install $(echo "${SRC_PACKAGES}" | sed 's|/host||g') && \
+    ./scripts/feeds install $(echo "${SRC_PACKAGES}" | sed 's|/host||g') && \
     echo "CONFIG_ALL=n" >.config && \
     echo "CONFIG_AUTOREMOVE=n" >>.config && \
     echo "CONFIG_AUTOREBUILD=n" >>.config && \
     for pkg in ${CFG_PACKAGES}; do echo "CONFIG_PACKAGE_${pkg}=y"; done >>.config && \
+    : "Normalize timestamps to avoid spurious rebuilds due to Docker layer mtime truncation" && \
+    SDE=$(sed -n 's/^SOURCE_DATE_EPOCH:=//p' include/version.mk) && test -n "$SDE" && \
+    find .config feeds -exec touch -h -d "@$SDE" {} + && \
     make defconfig && \
     for pkg in ${SRC_PACKAGES}; do make -j "$(nproc)" "package/${pkg}/compile"; done


### PR DESCRIPTION
The OpenWrt build hashes file timestamps at full (sub-second) precision to determine if packages need to be rebuilt. While the container is being built, these will reflect the actual time when those files were checked out from the feed. However when the files are baked into the container layer, the file timestamps end up being truncated to second precision, causing the stamp hashes to change. To avoid this, set them all to a fixed non-fractional timestamp.

Also fix a typo in the feed install line.