### PR TITLE
Refine /etc/matter layout for network-manager daemon

### DIFF
--- a/service/matter-netman/Makefile
+++ b/service/matter-netman/Makefile
@@ -15,7 +15,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=matter-netman
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE_URL:=https://github.com/project-chip/connectedhomeip.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_SUBMODULES:=\
@@ -49,7 +49,7 @@ define Package/matter-netman/default
   CATEGORY:=Network
   TITLE:=Matter Network Infrastructure Manager Daemon
   URL:=https://github.com/project-chip/connectedhomeip
-  DEPENDS:=+libstdcpp +libatomic +libubus +libubox
+  DEPENDS:=+libstdcpp +libatomic +libubus +libubox +jsonfilter
   USERID:=matter:matter
 endef
 
@@ -112,10 +112,10 @@ endif
 # Configuration / persistence
 CONF_DIR:=/etc/matter
 TARGET_CFLAGS+=\
-	-DCHIP_CONFIG_KVS_PATH=\"$(CONF_DIR)/chip_kvs.ini\" \
 	-DFATCONFDIR=\"$(CONF_DIR)\" \
-	-DSYSCONFDIR=\"$(CONF_DIR)\" \
-	-DLOCALSTATEDIR=\"$(CONF_DIR)\"
+	-DSYSCONFDIR=\"$(CONF_DIR)/data\" \
+	-DLOCALSTATEDIR=\"$(CONF_DIR)/data\" \
+	-DCHIP_CONFIG_KVS_PATH=\"$(CONF_DIR)/data/chip_kvs.ini\"
 
 # Device Information. Runtime information is configured by bootstrap.sh
 include $(INCLUDE_DIR)/version.mk

--- a/service/matter-netman/files/bootstrap.sh
+++ b/service/matter-netman/files/bootstrap.sh
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 type get_mac_label >/dev/null || . /lib/functions/system.sh
-type json_init >/dev/null || . /usr/share/libubox/jshn.sh
 
 random_uint32() {
 	hexdump -n 4 -e '4 "%u"' /dev/urandom
@@ -35,17 +34,7 @@ random_pincode() {
 }
 
 get_model_name() {
-	local model
-	local cfg="/etc/board.json"
-	[ -s "$cfg" ] || return
-	json_init
-	json_load "$(cat $cfg)"
-	if json_is_a model object; then
-		json_select model
-		json_get_var model name
-		json_select ..
-	fi
-	echo "$model"
+	jsonfilter -q -i /etc/board.json -e @.model.name
 }
 
 generate_factory_ini() {
@@ -62,13 +51,36 @@ generate_factory_ini() {
 }
 
 matter_bootstrap() {
-	mkdir -p /etc/matter
-	chown matter:matter /etc/matter
-	chmod 0700 /etc/matter
+	# create /etc/matter and /etc/matter/data if needed
+	if ! [ -d /etc/matter/data ]; then
+		if ! [ -d /etc/matter ]; then
+			mkdir -m 0750 /etc/matter
+			chgrp matter /etc/matter
+		fi
+		mkdir -m 0700 /etc/matter/data
+		chown matter:matter /etc/matter/data
+	fi
+
+	# generate factory config if necessary
 	local ini=/etc/matter/chip_factory.ini
 	if ! [ -s "$ini" ]; then
-		generate_factory_ini >"${ini}.tmp"
+		rm -f "${ini}.tmp"
+		( umask 277; generate_factory_ini >"${ini}.tmp" )
+		chown matter:matter "${ini}.tmp"
 		mv "${ini}.tmp" "$ini"
+	fi
+
+	# migration: /etc/matter used to be owned by matter
+	if ! [ -O /etc/matter ]; then
+		chmod 0400 /etc/matter/chip_factory.ini
+		chown matter:matter /etc/matter/chip_factory.ini
+		chmod 0750 /etc/matter
+		chown root:matter /etc/matter
+	fi
+
+	# migration: data used to live in /etc/matter directly
+	if [ -f /etc/matter/chip_kvs.ini -a ! -f /etc/matter/data/chip_kvs.ini ]; then
+		mv -n /etc/matter/chip_config.ini /etc/matter/chip_counters.ini /etc/matter/chip_kvs.ini /etc/matter/data/
 	fi
 }
 

--- a/service/matter-netman/files/matter.init
+++ b/service/matter-netman/files/matter.init
@@ -23,7 +23,7 @@ start_service() {
 	. /usr/share/matter/bootstrap.sh
 
 	procd_open_instance
-	procd_set_param command "$PROG"
+	procd_set_param command /bin/sh -c 'umask 027; exec "$@"' - "$PROG"
 	procd_set_param user matter
 	procd_set_param group matter
 	procd_set_param respawn

--- a/third_party/openthread-br/Makefile
+++ b/third_party/openthread-br/Makefile
@@ -57,7 +57,7 @@ define Package/openthread-br/Default
   CATEGORY:=Network
   TITLE:=OpenThread Border Router
   URL:=https://github.com/openthread/ot-br-posix
-  DEPENDS:=+libstdcpp +OPENTHREADBR_SHARED_MBEDTLS:libmbedtls +libjson-c +libubus +libubox +kmod-usb-acm +kmod-tun
+  DEPENDS:=+libstdcpp +OPENTHREADBR_SHARED_MBEDTLS:libmbedtls +libjson-c +libubus +libubox +kmod-usb-acm +kmod-tun +jsonfilter
 endef
 
 define Package/openthread-br/Default/description


### PR DESCRIPTION
Change /etc/matter to be owned by root and group-readable and move non-factory data into /etc/matter/data; only this sub-directory is now owned by the matter user.  Change permissions of chip_factory.ini to be no longer group or world readable. Run the daemon with umask 027 instead of the default 022.

These changes make it easier to "factory reset" the Matter service by deleting /etc/matter/data, and lay the ground work for giving another daemon read-access to some files managed by the matter daemon via the matter group (e.g. letting hostapd read /etc/matter/network).

Also simplify get_model_name() to use jsonfilter instead of jshn (this is the same logic also used in the otbr-agent init script). jsonfilter is a dependency of the base-files package, so is always already available in practice. Also add the missing jsonfilter dependency to the openthread-br package.