### PR TITLE
Matter netman add rpcd

### DIFF
--- a/service/matter-netman/Makefile
+++ b/service/matter-netman/Makefile
@@ -49,7 +49,7 @@ define Package/matter-netman/default
   CATEGORY:=Network
   TITLE:=Matter Network Infrastructure Manager Daemon
   URL:=https://github.com/project-chip/connectedhomeip
-  DEPENDS:=+libstdcpp +libatomic +libubus +libubox +jsonfilter
+  DEPENDS:=+libstdcpp +libatomic +libubus +libubox +jsonfilter +rpcd
   USERID:=matter:matter
 endef
 


### PR DESCRIPTION
We need rpcd to query the UCI configuration over ubus.